### PR TITLE
Add the ability to override protocol from transform

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ module.exports = (url, options, callback) => {
     if (options.transform) {
       parsed = options.transform(parsed);
       if (parsed.protocol) {
-        httpLib = httpLibs[parsed.protocol]
+        httpLib = httpLibs[parsed.protocol];
       }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,6 +104,9 @@ module.exports = (url, options, callback) => {
 
     if (options.transform) {
       parsed = options.transform(parsed);
+      if (parsed.protocol) {
+        httpLib = httpLibs[parsed.protocol]
+      }
     }
 
     myreq = httpLib.get(parsed, (res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -307,8 +306,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "isexe": {
       "version": "1.1.2",
@@ -367,7 +365,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
       "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-buffer": "^1.0.2"
       }
@@ -405,8 +402,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.3",
@@ -654,8 +650,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "resolve": {
       "version": "1.1.7",

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -219,6 +219,23 @@ describe('Make a request', () => {
         done();
       });
     });
+    it('Calls `transform` function and customizes request with protocol changing', (done) => {
+      const scope = nock('http://that.com')
+        .get('/')
+        .reply(200, '[  ]');
+      miniget('https://that.com', {
+        transform: (parsed) => {
+          parsed.protocol = 'http:';
+          return parsed;
+        },
+      }, (err, res, body) => {
+        scope.done();
+        assert.ifError(err);
+        assert.equal(res.statusCode, 200);
+        assert.equal(body, '[  ]');
+        done();
+      });
+    });
   });
 
   describe('that disconnects before end', () => {


### PR DESCRIPTION
I've added ability to proper override protocol from transform function. 

I need this because in another your package, [ytdl-core](https://github.com/fent/node-ytdl-core) i'm unable to load https page through http proxy, because it's trying to access http server with https client and fails.

Here is already opened issue:

https://github.com/fent/node-ytdl-core/issues/341