### PR TITLE
expose request object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -263,8 +263,6 @@ function Miniget(url: string, options: Miniget.Options = {}): Miniget.Stream {
       res.on('error', onError);
       forwardEvents(res, responseEvents);
     });
-    activeRequest.emit('request', activeRequest);
-    activeRequest.end();
     activeRequest.on('error', onError);
     activeRequest.on('close', onRequestClose);
     forwardEvents(activeRequest, requestEvents);
@@ -272,6 +270,7 @@ function Miniget(url: string, options: Miniget.Options = {}): Miniget.Stream {
       streamDestroy(destroyErr);
     }
     stream.emit('request', activeRequest);
+    activeRequest.end();
   };
 
   stream.abort = (err?: Error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { PassThrough, Transform } from 'stream';
 
 const httpLibs: {
   [key: string]: {
-    get: (options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void) => ClientRequest;
+    request: (options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void) => ClientRequest;
   };
 } = { 'http:': http, 'https:': https };
 const redirectStatusCodes = new Set([301, 302, 303, 307, 308]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ function Miniget(url: string, options: Miniget.Options = {}): Miniget.Stream {
       }
     };
 
-    activeRequest = httpLib.get(parsed, (res: IncomingMessage) => {
+    activeRequest = httpLib.request(parsed, (res: IncomingMessage) => {
       // Needed for node v10, v12.
       // istanbul ignore next
       if (stream.destroyed) { return; }
@@ -263,6 +263,8 @@ function Miniget(url: string, options: Miniget.Options = {}): Miniget.Stream {
       res.on('error', onError);
       forwardEvents(res, responseEvents);
     });
+    activeRequest.emit('request', activeRequest);
+    activeRequest.end();
     activeRequest.on('error', onError);
     activeRequest.on('close', onRequestClose);
     forwardEvents(activeRequest, requestEvents);


### PR DESCRIPTION
expose the un-ended request object by reversing what nodejs does internally with there [http#get](https://github.com/nodejs/node/blob/master/lib/http.js#L53)
would allow for out-of-project-scope usage