### PR TITLE
feat: add opt "prefix"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ namespace Miniget {
     highWaterMark?: number;
     transform?: (parsedUrl: RequestOptions) => RequestOptions;
     acceptEncoding?: { [key: string]: () => Transform };
+    prefix?: string;
   }
 
   export type defaultOptions = Miniget.Options;
@@ -74,6 +75,7 @@ function Miniget(url: string, options: Miniget.Options = {}): Miniget.Stream {
   let acceptRanges = false;
   let rangeStart = 0, rangeEnd: number;
   let downloaded = 0;
+  url = opts.prefix ? prefix + url : url;
 
   // Check if this is a ranged request.
   if (opts.headers?.Range) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ function Miniget(url: string, options: Miniget.Options = {}): Miniget.Stream {
   let acceptRanges = false;
   let rangeStart = 0, rangeEnd: number;
   let downloaded = 0;
-  url = opts.prefix ? prefix + url : url;
+  url = opts.prefix ? opts.prefix + url : url;
 
   // Check if this is a ranged request.
   if (opts.headers?.Range) {


### PR DESCRIPTION
This option is a string, that simply is prepended to the request url.

For example, `miniget('https://example.org/',{prefix:'https://proxy.org?request='})`
 will just request `https://proxy.org?request=https://example.org/`.

This allows for easy use of third-party proxying/cors-avoidance servers in libraries that use miniget, like ytdl-core.