### PR TITLE
fix: stop requiring url & make webpack possible again

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { RequestOptions, IncomingMessage, ClientRequest, default as http } from 'http';
 import { EventEmitter } from 'events';
 import https from 'https';
-import { URL } from 'url';
 import { PassThrough, Transform } from 'stream';
 
 

--- a/test/request-test.ts
+++ b/test/request-test.ts
@@ -4,7 +4,6 @@ import zlib from 'zlib';
 import assert from 'assert';
 import { Transform } from 'stream';
 import { IncomingMessage, ClientRequest, RequestOptions } from 'http';
-import { URL } from 'url';
 
 import miniget from '../dist';
 


### PR DESCRIPTION
Replaces: https://github.com/fent/node-miniget/pull/58
Original Issue: https://github.com/fent/node-ytdl-core/issues/882